### PR TITLE
If we're using DBIx::Class::EncodedColumn, then we don't need to explicitly encode passwords manually

### DIFF
--- a/Example/lib/Example.pm
+++ b/Example/lib/Example.pm
@@ -41,15 +41,12 @@ post '/register' => sub {
         return template 'register' => { 'title' => 'Register', 'error' => 'Passwords do not match' };
     }
     
-    # Encrypt the password
-    my $encrypted_password = sha256_hex($password);
-    
     # Add user registration logic (e.g., save user to database)
     my $schema = get_schema();
     eval {
         $schema->resultset('User')->create({
             username => $username,
-            password => $encrypted_password,
+            password => $password,
             email    => $email,
         });
     };
@@ -79,7 +76,7 @@ post '/login' => sub {
     my $schema = get_schema();
     my $user = $schema->resultset('User')->find({ username => $username });
     
-    if ($user && $user->password eq sha256_hex($password)) {
+    if ($user && $user->check_password($password)) {
         # Log the result of the authentication attempt (success)
         debug "Authentication successful for username: $username"; # Pa940
         

--- a/Example/t/004_database_interactions.t
+++ b/Example/t/004_database_interactions.t
@@ -5,7 +5,6 @@ use Test::More;
 use Example::Schema;
 use DBIx::Class::Schema::Loader qw/ make_schema_at /;
 use Example::Util::SchemaLoader;
-use Digest::SHA qw(sha256_hex);
 
 Example::Util::SchemaLoader::load_schema();
 
@@ -15,11 +14,10 @@ my $schema = Example::Schema->connect('dbi:SQLite:dbname=Example/db/example.db')
 # Test user creation in the database
 subtest 'User creation' => sub {
     my $password = 'testpassword';
-    my $encrypted_password = sha256_hex($password);
 
     my $user = $schema->resultset('User')->create({
         username => 'testuser',
-        password => $encrypted_password,
+        password => $password,
         email    => 'testuser@example.com',
     });
 

--- a/Example/t/005_user_result_class.t
+++ b/Example/t/005_user_result_class.t
@@ -3,7 +3,6 @@ use warnings;
 
 use Test::More;
 use Example::Schema;
-use Digest::SHA qw(sha256_hex);
 use Example::Util::SchemaLoader;
 
 Example::Util::SchemaLoader::load_schema();
@@ -15,7 +14,7 @@ my $schema = Example::Schema->connect('dbi:SQLite:dbname=Example/db/example.db')
 subtest 'Unique constraints' => sub {
     my $user1 = $schema->resultset('User')->create({
         username => 'uniqueuser',
-        password => sha256_hex('password'),
+        password => 'password',
         email    => 'uniqueuser@example.com',
     });
 
@@ -24,7 +23,7 @@ subtest 'Unique constraints' => sub {
     eval {
         my $user2 = $schema->resultset('User')->create({
             username => 'uniqueuser',
-            password => sha256_hex('password'),
+            password => 'password',
             email    => 'uniqueuser2@example.com',
         });
     };
@@ -33,7 +32,7 @@ subtest 'Unique constraints' => sub {
     eval {
         my $user3 = $schema->resultset('User')->create({
             username => 'uniqueuser3',
-            password => sha256_hex('password'),
+            password => 'password',
             email    => 'uniqueuser@example.com',
         });
     };
@@ -43,16 +42,15 @@ subtest 'Unique constraints' => sub {
 # Test password encryption
 subtest 'Password encryption' => sub {
     my $password = 'plaintextpassword';
-    my $encrypted_password = sha256_hex($password);
 
     my $user = $schema->resultset('User')->create({
         username => 'encryptionuser',
-        password => $encrypted_password,
+        password => $password,
         email    => 'encryptionuser@example.com',
     });
 
     ok($user, 'User created with encrypted password');
-    is($user->password, $encrypted_password, 'Password is encrypted');
+    ok($user->check_password($password), 'Password is encrypted and verified');
 };
 
 done_testing();

--- a/Example/t/007_session_management.t
+++ b/Example/t/007_session_management.t
@@ -7,7 +7,6 @@ use Test::More;
 use Plack::Test;
 use HTTP::Request::Common;
 use Ref::Util qw<is_coderef>;
-use Digest::SHA qw(sha256_hex);
 
 Example::Util::SchemaLoader::load_schema();
 
@@ -15,7 +14,7 @@ Example::Util::SchemaLoader::load_schema();
 my $schema = Example::Schema->connect('dbi:SQLite:dbname=Example/db/example.db');
 $schema->resultset('User')->create({
     username => 'testuser',
-    password => sha256_hex('password'),
+    password => 'password',
     email    => 'testuser@example.com',
 });
 


### PR DESCRIPTION
Fixes #58

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/dancer-example/issues/58?shareId=3155efbc-f436-4757-8e4a-ff5fcf97b1ea).